### PR TITLE
Fix header to be older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,17 +6,13 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>RAG Chatbot</title>
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body data-theme="dark">
     <div class="container">
         <header>
             <div class="header-content">
-                <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
                 <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
                     <svg class="theme-icon theme-icon-light" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -76,7 +76,6 @@ body {
 /* Header */
 header {
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     padding: 1rem 2rem;
     flex-shrink: 0;
     transition: all var(--transition-duration) var(--transition-easing);
@@ -84,25 +83,12 @@ header {
 
 .header-content {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     max-width: 1200px;
     margin: 0 auto;
 }
 
-.header-text {
-    flex: 1;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
 
 /* Theme Toggle Button */
 .theme-toggle {
@@ -165,11 +151,6 @@ body[data-theme="light"] .theme-icon-dark {
     transform: rotate(0deg) scale(1);
 }
 
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -840,16 +821,7 @@ details[open] .suggested-header::before {
     }
     
     .header-content {
-        flex-direction: row;
-        gap: 1rem;
-    }
-    
-    .header-text {
-        flex: 1;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
+        justify-content: flex-end;
     }
     
     .theme-toggle {


### PR DESCRIPTION
Reverts the header to a simpler design as requested in issue #2.

## Changes:
- Removed 'Course Materials Assistant' header text
- Removed 'Ask questions about courses, instructors, and content' subtitle
- Removed horizontal border line below header
- Preserved theme toggle functionality
- Updated page title and cleaned up CSS

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)